### PR TITLE
Only initialize SYEngine for non-arm64 platform

### DIFF
--- a/BiliLite/App.xaml.cs
+++ b/BiliLite/App.xaml.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
@@ -96,7 +97,11 @@ namespace BiliLite
 
         private async void Navigation(object arguments, bool prelaunch=false)
         {
-            SYEngine.Core.Initialize();
+            // We don't have ARM64 support of SYEngine.
+            if (RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            {
+                SYEngine.Core.Initialize();
+            }
             InitBili();
             Frame rootFrame = Window.Current.Content as Frame;
 

--- a/BiliLite/Controls/Player.xaml.cs
+++ b/BiliLite/Controls/Player.xaml.cs
@@ -54,7 +54,6 @@ namespace BiliLite.Controls
         MultiFlv,
         Dash
     }
-
     //TODO 写得太复杂了，需要重写
     public sealed partial class Player : UserControl, IDisposable, INotifyPropertyChanged
     {

--- a/BiliLite/Controls/Player.xaml.cs
+++ b/BiliLite/Controls/Player.xaml.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using System.Threading.Tasks;
@@ -53,6 +54,7 @@ namespace BiliLite.Controls
         MultiFlv,
         Dash
     }
+
     //TODO 写得太复杂了，需要重写
     public sealed partial class Player : UserControl, IDisposable, INotifyPropertyChanged
     {
@@ -227,9 +229,12 @@ namespace BiliLite.Controls
         {
             this.InitializeComponent();
 
-
-            SYEngine.Core.ForceNetworkMode = true;
-            SYEngine.Core.ForceSoftwareDecode = !SettingHelper.GetValue<bool>(SettingHelper.Player.HARDWARE_DECODING, false);
+            // We don't have ARM64 support of SYEngine.
+            if (RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            {
+                SYEngine.Core.ForceNetworkMode = true;
+                SYEngine.Core.ForceSoftwareDecode = !SettingHelper.GetValue<bool>(SettingHelper.Player.HARDWARE_DECODING, false);
+            }
             //_ffmpegConfig.StreamBufferSize = 655360;//1024 * 30;
 
         }


### PR DESCRIPTION
**问题**
SYEngine 只有 x64, x86 和 ARMv7 的包: https://github.com/yunfandev/SYEngine.uwp
所以 ARM64 在 .NET Native 下会 Crash，暂时注释掉 SYEngine 的逻辑。

**测试**
测试了很多基于Dash也就是.264 HEVC的视频，因为使用的是Native播放器没遇到什么问题，但是对于FLV的播放没有测试