### PR TITLE
使FFmpegInteropX作为子模块

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "FFmpegInteropX"]
+	path = FFmpegInteropX
+	url = https://github.com/ffmpeginteropx/FFmpegInteropX.git

--- a/BiliLite.sln
+++ b/BiliLite.sln
@@ -13,7 +13,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiTester", "ApiTester\ApiT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestAPP", "TestAPP\TestAPP.csproj", "{B2A4FF84-FE5A-437A-9BF9-610E0F87C240}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FFmpegInterop", "..\FFmpegInteropX\FFmpegInterop\FFmpegInterop.vcxproj", "{9CFA3B3E-B7AF-4629-84E2-C962C5B046B1}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FFmpegInterop", "FFmpegInteropX\FFmpegInterop\FFmpegInterop.vcxproj", "{9CFA3B3E-B7AF-4629-84E2-C962C5B046B1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BiliLite.gRPC", "BiliLite.gRPC\BiliLite.gRPC.csproj", "{AEE3DCAA-2C3C-4308-B602-4797994219D7}"
 EndProject

--- a/BiliLite/BiliLite.csproj
+++ b/BiliLite/BiliLite.csproj
@@ -25,7 +25,6 @@
     <AppxBundle>Never</AppxBundle>
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <PackageCertificateThumbprint>6DDE612D6A80D159B45492E9C1F6E5D5491E6129</PackageCertificateThumbprint>
     <PackageCertificateKeyFile />
     <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>
   </PropertyGroup>
@@ -878,6 +877,10 @@
     <ProjectReference Include="..\BiliLite.JSBridge\BiliLite.JSBridge.csproj">
       <Project>{809c7636-0af1-4695-9230-22f74d7b1327}</Project>
       <Name>BiliLite.JSBridge</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\FFmpegInteropX\FFmpegInterop\FFmpegInterop.vcxproj">
+      <Project>{9cfa3b3e-b7af-4629-84e2-c962c5b046b1}</Project>
+      <Name>FFmpegInterop</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
项目里好像不会自动下载`FFmpegInteropX`，也没看到这方面的说明，把`FFmpegInteropX`变成子模块会方便管理一点
还有`BiliLite/BiliLite.csproj`里的`PackageCertificateThumbprint`放进本地的`BiliLite/BiliLite.csproj.user`可以避免被其他人误修改